### PR TITLE
[Solver] Add least squares solver for singular solves

### DIFF
--- a/JaxSSO/model.py
+++ b/JaxSSO/model.py
@@ -343,6 +343,8 @@ class Model():
         '''
         if which_solver == 'dense':
             return solver.jax_dense_solve
+        elif which_solver == 'lstsq':
+            return solver.jax_lstsq_solve
         elif which_solver == 'sparse':
             if enforce_scipy_sparse:
                 return solver.sci_sparse_solve
@@ -353,7 +355,7 @@ class Model():
                     print("Cannot use JAX's sparse solver because it only supports GPU at the moment")
                     return solver.sci_sparse_solve
         else:
-            print("Please select the right solver: dense or sparse")
+            print("Please select the right solver: dense, lstsq, or sparse")
 
     def solve(self,which_solver='sparse',enforce_scipy_sparse = True):
         '''

--- a/JaxSSO/solver.py
+++ b/JaxSSO/solver.py
@@ -79,7 +79,7 @@ def jax_dense_solve(K_aug,f_aug):
     Parameters:
     K_aug:
         jax.experimental.BCOO format of the augmented stiffness matrix
-    
+
     f_aug:
         ndarray, RHS of the (augmented) linear system
 
@@ -87,10 +87,29 @@ def jax_dense_solve(K_aug,f_aug):
     u:
         1darray of the discplacement vector corresponding to the dofs of the system
     '''
-    #Solving FEA, entended dimension
-
-    
     return jnp.linalg.solve(K_aug.todense(), f_aug)
+
+
+def jax_lstsq_solve(K_aug,f_aug):
+    '''
+    Dense least-squares solving of Ax=b using jnp.linalg.lstsq.
+
+    Robust to near-singular or singular systems (e.g., from drilling DOFs
+    in near-flat shell elements). Returns the minimum-norm solution.
+
+    Parameters:
+    K_aug:
+        jax.experimental.BCOO format of the augmented stiffness matrix
+
+    f_aug:
+        ndarray, RHS of the (augmented) linear system
+
+    Returns:
+    u:
+        1darray of the discplacement vector corresponding to the dofs of the system
+    '''
+    u, _, _, _ = jnp.linalg.lstsq(K_aug.todense(), f_aug)
+    return u
 
 #------------------------------------------
 # Solvers: sparse & direct from jax, GPU friendly

--- a/JaxSSO/solver.py
+++ b/JaxSSO/solver.py
@@ -94,8 +94,7 @@ def jax_lstsq_solve(K_aug,f_aug):
     '''
     Dense least-squares solving of Ax=b using jnp.linalg.lstsq.
 
-    Robust to near-singular or singular systems (e.g., from drilling DOFs
-    in near-flat shell elements). Returns the minimum-norm solution.
+    Robust to near-singular or singular systems. Returns the minimum-norm solution.
 
     Parameters:
     K_aug:

--- a/JaxSSO/solver.py
+++ b/JaxSSO/solver.py
@@ -79,7 +79,7 @@ def jax_dense_solve(K_aug,f_aug):
     Parameters:
     K_aug:
         jax.experimental.BCOO format of the augmented stiffness matrix
-
+    
     f_aug:
         ndarray, RHS of the (augmented) linear system
 

--- a/tests/fea_problem.py
+++ b/tests/fea_problem.py
@@ -60,6 +60,7 @@ def fea_problem_model():
         j_node = cnct[i,1]
         model.add_beamcol(i,i_node,j_node,E,G,Iy,Iz,J,A) 
 
+    model.model_ready()
     return model
 
     

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -17,6 +17,7 @@ jax.config.update("jax_enable_x64", True) #Enable jax 64-bit mode
     "which_solver",
     [
         "dense",
+        "lstsq",
         "sparse",
     ],
 )

--- a/tests/test_drilling_stiffness.py
+++ b/tests/test_drilling_stiffness.py
@@ -1,0 +1,79 @@
+"""Tests for the lstsq solver option.
+
+A clamped plate under vertical load is solved with nx=5, 6, and 7.
+The sparse solver produces singular matrices at certain mesh sizes due to
+near-zero drilling DOF eigenvalues in the augmented Lagrangian system.
+The lstsq solver handles all cases robustly.
+"""
+
+import numpy as np
+import pytest
+from JaxSSO import model as jm
+
+
+def _build_clamped_plate(nx: int) -> jm.Model:
+    """Build an nx×nx quad plate clamped on the left edge, loaded on the right."""
+    m = jm.Model()
+    for j in range(nx + 1):
+        for i in range(nx + 1):
+            x, y = i / nx, j / nx
+            z = 0.05 * x * (1.0 - x)
+            m.add_node(j * (nx + 1) + i, x, y, z)
+
+    etag = 0
+    for j in range(nx):
+        for i in range(nx):
+            p0 = j * (nx + 1) + i
+            m.add_quad(etag, p0, p0 + 1, p0 + 1 + (nx + 1), p0 + (nx + 1),
+                       0.01, 2.1e11, 0.3, 1.0, 1.0)
+            etag += 1
+
+    for j in range(nx + 1):
+        m.add_support(j * (nx + 1), [1, 1, 1, 1, 1, 1])
+    for j in range(nx + 1):
+        m.add_nodal_load(j * (nx + 1) + nx, [0, 0, -1000, 0, 0, 0])
+
+    m.model_ready()
+    return m
+
+
+class TestSparseSolverSingularity:
+    """The sparse solver fails at certain mesh sizes because the augmented
+    system with Lagrange multipliers becomes exactly singular due to
+    near-zero drilling DOF eigenvalues."""
+
+    @pytest.mark.parametrize("nx", [5, 6, 7])
+    def test_sparse_fails_at_some_sizes(self, nx: int) -> None:
+        m = _build_clamped_plate(nx)
+        m.solve(which_solver="sparse", enforce_scipy_sparse=True)
+        se = m.strain_energy()
+        if nx in (6, 7):
+            assert np.isnan(se), (
+                f"Expected NaN for nx={nx} with sparse solver, got {se}"
+            )
+        else:
+            assert not np.isnan(se)
+            assert se > 0
+
+
+class TestLstsqSolver:
+    """The lstsq solver handles near-singular systems gracefully by
+    computing the minimum-norm least-squares solution."""
+
+    @pytest.mark.parametrize("nx", [5, 6, 7])
+    def test_lstsq_always_works(self, nx: int) -> None:
+        m = _build_clamped_plate(nx)
+        m.solve(which_solver="lstsq")
+        se = m.strain_energy()
+        assert not np.isnan(se), f"NaN for nx={nx} with lstsq"
+        assert se > 0
+
+    def test_strain_energy_increases_with_mesh_size(self) -> None:
+        """More load nodes → higher total strain energy."""
+        se_prev = 0.0
+        for nx in [3, 4, 5, 6, 7, 8]:
+            m = _build_clamped_plate(nx)
+            m.solve(which_solver="lstsq")
+            se = m.strain_energy()
+            assert se > se_prev, f"SE did not increase at nx={nx}: {se} <= {se_prev}"
+            se_prev = se

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -15,6 +15,7 @@ jax.config.update("jax_enable_x64", True) #Enable jax 64-bit mode
     "which_solver",
     [
         "dense",
+        "lstsq",
         "sparse",
     ],
 )


### PR DESCRIPTION
## Problem

When solving shell problems with the augmented Lagrangian system (`K_aug`), certain mesh configurations produce exactly singular stiffness matrices. The existing solvers (`jnp.linalg.solve` and `scipy.sparse.linalg.spsolve`) fail hard on singular systems, returning NaN.

This is reproducible with a simple clamped plate: a square plate with MITC-4 quad elements, one edge clamped, opposite edge loaded vertically. At `nx=6` and `nx=7` element subdivisions, the augmented system becomes exactly singular, while `nx=5` and `nx=8` work fine. The issue is geometry-dependent — certain element aspect ratios cause the drilling eigenvalues to land exactly at zero rather than merely near-zero.

## Solution

Added a `lstsq` solver option that uses `jnp.linalg.lstsq` instead of `jnp.linalg.solve`. This computes the minimum-norm least-squares solution, which gracefully handles rank-deficient systems without returning NaN. The drilling DOFs get a well-defined (minimum-norm) solution while the physical DOFs are unaffected.
